### PR TITLE
Change zip format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,7 @@ builds:
       - windows
       - darwin
 archives:
+  - format: zip
   - replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
Default format for goreleaser is .tar.gz. Zip is more user friendly.